### PR TITLE
chore: add catalog metadata

### DIFF
--- a/.catalog/sonarqube-community-branch-plugin.yaml
+++ b/.catalog/sonarqube-community-branch-plugin.yaml
@@ -1,0 +1,24 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: devops-sonarqube-community-branch-plugin
+  title: SonarQube Community Branch Plugin
+  description: A plugin that enables branch analysis and pull request decoration for SonarQube Community Build deployments.
+  annotations:
+    # github plugin
+    github.com/project-slug: AlaudaDevops/sonarqube-community-branch-plugin
+    # acp cicd plugin
+    # acp.cpaas.io/ci-pipeline: ""
+    acp.cpaas.io/instance: edge.alauda.cn
+    # sonarqube plugin
+    sonarqube.org/project-key: github.com-AlaudaDevops-sonarqube-community-branch-plugin
+    acp.cpaas.io/owner: kychen@alauda.io
+
+    # 组件属性，区别是否部署时必带的核心组件,可选值为 core 和 plugin。
+    acp.cpaas.io/functional-attributes: plugin
+
+spec:
+  type: plugin
+  system: system:alauda-devops-system
+  lifecycle: production
+  owner: devops

--- a/.catalog/sonarqube-community-branch-plugin.yaml
+++ b/.catalog/sonarqube-community-branch-plugin.yaml
@@ -18,7 +18,7 @@ metadata:
     acp.cpaas.io/functional-attributes: plugin
 
 spec:
-  type: plugin
+  type: library
   system: system:alauda-devops-system
   lifecycle: production
   owner: devops


### PR DESCRIPTION
## Summary
- add a Backstage catalog component definition for sonarqube-community-branch-plugin
- align the catalog file structure with AlaudaDevops/connectors-operator#965

## Testing
- not run (YAML metadata only)